### PR TITLE
Add note for windows about formatting bash script

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,8 +240,8 @@ Windows is derived from DOS while Linux and Mac are derived from UNIX, this mean
 there are some incompatibilities. Namely, you cant run bash (`.sh`) scripts on native Windows.
 
 There are a couple ways to work around this issue.
-1. Install WSL (windows subsystem for linux). This essentially runs a linux kernel inside windows and allows running full programs in Debian, Ubuntu, Fedora, etc.
-    If you dont have a reason to use WSL1, install WSL2 as it is more up to data with better features. Refer to the [Microsoft Install Instructions](https://docs.microsoft.com/en-us/windows/wsl/install-win10). After having installed WSL and your Linux distro of choice, open the repo folder in cmd or powershell and enter `wsl`. This will put you in a linux command terminal. Then, refer to the formatting instructions under [Part III: Making a Change](#part-iii-making-a-change). You will likely need to install python dependacies since the linux environement is separate from windows.
+1. **Easy:** Use Git bash! If you have Git already set up on your computer from the first step, (unless you disabled it) you should already have git bash installed. 
+    This is a straightforward bash terminal that supports a wide range of Unix style commands and programs. To open a git bash terminal, search for "Git bash" in the start menu. Once started, switch to the repo's directory and refer back to the formatting instructions under [Part III: Making a Change](#part-iii-making-a-change).
 
-2. Install CYGWIN. CYGWIN interprets linux/unix programs to run natively on windows. This means that programs require a recompile, 
-    leading to complication and a lot of hair pulling. WSL was functionally the replacement for CYGWIN, so use WSL unless you have a reason not to.
+2. **Hard:** Install WSL (windows subsystem for linux). This essentially runs a linux kernel inside windows and allows running full programs in Debian, Ubuntu, Fedora, etc.
+    If you dont have a reason to use WSL1, install WSL2 as it is more up to data with better features. Refer to the [Microsoft Install Instructions](https://docs.microsoft.com/en-us/windows/wsl/install-win10). After having installed WSL and your Linux distro of choice, open the repo folder in cmd or powershell and enter `wsl`. This will put you in a linux command terminal. Then, refer to the formatting instructions under [Part III: Making a Change](#part-iii-making-a-change). You will likely need to install python dependacies since the linux environement is separate from windows.

--- a/README.md
+++ b/README.md
@@ -235,13 +235,11 @@ the team!
 
 ### Windows Users
 
-The formatting script in this repository is written in bash. Unfortunately, 
-Windows is derived from DOS while Linux and Mac are derived from UNIX, this means
-there are some incompatibilities. Namely, you cant run bash (`.sh`) scripts on native Windows.
+The formatting script in this repository is written for Bash. Unfortunately, Windows diverges from Linux and Mac in standard shell syntax and tools/programs, this leads to incompatibilities. Ultimately, you can't run Bash (`.sh`) scripts directly using CMD or Powershell, you need an extra tool.
 
 There are a couple ways to work around this issue.
-1. **Easy:** Use Git bash! If you have Git already set up on your computer from the first step, (unless you disabled it) you should already have git bash installed. 
-    This is a straightforward bash terminal that supports a wide range of Unix style commands and programs. To open a git bash terminal, search for "Git bash" in the start menu. Once started, switch to the repo's directory and refer back to the formatting instructions under [Part III: Making a Change](#part-iii-making-a-change).
+1. **Easy:** Use Git Bash! If you have Git set up on your computer from the first step, you should already have Git Bash installed (unless you disabled it). 
+    This is a straightforward Bash shell that supports a wide range of Unix style commands and programs. To open a Git Bash terminal, search for "Git Bash" in the start menu. Once started, switch to the repo's directory and refer back to the formatting instructions under [Part III: Making a Change](#part-iii-making-a-change).
 
-2. **Hard:** Install WSL (windows subsystem for linux). This essentially runs a linux kernel inside windows and allows running full programs in Debian, Ubuntu, Fedora, etc.
-    If you dont have a reason to use WSL1, install WSL2 as it is more up to data with better features. Refer to the [Microsoft Install Instructions](https://docs.microsoft.com/en-us/windows/wsl/install-win10). After having installed WSL and your Linux distro of choice, open the repo folder in cmd or powershell and enter `wsl`. This will put you in a linux command terminal. Then, refer to the formatting instructions under [Part III: Making a Change](#part-iii-making-a-change). You will likely need to install python dependacies since the linux environement is separate from windows.
+2. **Hard:** Install WSL (Windows Subsystem for Linux). This effectively runs a Linux kernel inside Windows and allows running full programs in Debian, Ubuntu, Fedora, etc.
+    If you don't have a reason to use WSL1, install WSL2 as it is more up to data and has more features. Refer to the [Microsoft Install Instructions](https://docs.microsoft.com/en-us/windows/wsl/install-win10). After having installed WSL and your Linux distro of choice (Ubuntu 20.04 recommended), open the repo folder in CMD or Powershell and enter `wsl`. This will put you in a Linux command shell. Then, refer to the formatting instructions under [Part III: Making a Change](#part-iii-making-a-change). You will likely need to install Python dependacies since the Linux environement is separate from Windows.

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ This repository has an automatic formatting script, located in the
 like extra newlines and whitespace floating around. To use it, run
 `./tools/format.sh` from the root of the repository - you'll generally
 want to do this before each commit, or at least before making pull
-requests.
+requests. (_For Windows, refer to the [note in the appendix](#windows-users)_)
 
 Finally, run the unit tests with `pytest` and make sure that your new
 test both runs and passes. If it fails or doesn't run, you've done
@@ -229,3 +229,19 @@ software onboarding! Whenever you're ready to get started, take a look
 at our [good first issues](https://github.com/issues?q=is%3Aissue+user%3Awaterloo-rocketry+is%3Aopen+no%3Aassignee+label%3A"good+first+issue")
 and let the software leads know that you're looking for work. Welcome to
 the team!
+
+
+## Appendix
+
+### Windows Users
+
+The formatting script in this repository is written in bash. Unfortunately, 
+Windows is derived from DOS while Linux and Mac are derived from UNIX, this means
+there are some incompatibilities. Namely, you cant run bash (`.sh`) scripts on native Windows.
+
+There are a couple ways to work around this issue.
+1. Install WSL (windows subsystem for linux). This essentially runs a linux kernel inside windows and allows running full programs in Debian, Ubuntu, Fedora, etc.
+    If you dont have a reason to use WSL1, install WSL2 as it is more up to data with better features. Refer to the [Microsoft Install Instructions](https://docs.microsoft.com/en-us/windows/wsl/install-win10). After having installed WSL and your Linux distro of choice, open the repo folder in cmd or powershell and enter `wsl`. This will put you in a linux command terminal. Then, refer to the formatting instructions under [Part III: Making a Change](#part-iii-making-a-change). You will likely need to install python dependacies since the linux environement is separate from windows.
+
+2. Install CYGWIN. CYGWIN interprets linux/unix programs to run natively on windows. This means that programs require a recompile, 
+    leading to complication and a lot of hair pulling. WSL was functionally the replacement for CYGWIN, so use WSL unless you have a reason not to.


### PR DESCRIPTION
Currently, there is a formatting bash script in the onboarding repository, but no notes about how to run it on a windows system. Hopefully someone who is looking to help on the team has worked with Linux or knows about WSL, but notation should be provided for those less aware.

Yeah, Yeah ... I use windows. I'm a Mech,I need it for Solidworks and such.
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/software-onboarding/8)
<!-- Reviewable:end -->
